### PR TITLE
Change the version for tensordict to fix test failures

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -31,7 +31,7 @@ RUN pip uninstall -y vllm && \
 COPY . .
 
 # Install dependencies
-RUN pip install "tensordict<0.6" --no-deps && \
+RUN pip install "tensordict==0.6.2" --no-deps && \
     pip install accelerate \
     codetiming \
     datasets \


### PR DESCRIPTION
The PR addresses changing the tensordict version for Verl Dockerfile.rocm. This needs to be done to fix some test failures 
