### PR TITLE
[deployment, single_controller, trainer] feat: ROCm 7.2 support (Docker, Ray HIP visibility).

### DIFF
--- a/docker/Dockerfile.rocm7.2
+++ b/docker/Dockerfile.rocm7.2
@@ -1,0 +1,60 @@
+# default base image
+ARG REMOTE_VLLM="1"
+ARG COMMON_WORKDIR=/app
+ARG BASE_IMAGE=rocm/vllm-dev:preview_releases_rocm_v0.16.0_20260211
+
+FROM ${BASE_IMAGE} AS base
+
+ARG ARG_PYTORCH_ROCM_ARCH
+ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
+
+# Install some basic utilities
+RUN apt-get update -q -y && apt-get install -q -y \
+    sqlite3 libsqlite3-dev libfmt-dev libmsgpack-dev libsuitesparse-dev \
+    apt-transport-https ca-certificates wget curl rsync
+# Remove sccache
+RUN python3 -m pip install --upgrade pip
+RUN apt-get purge -y sccache; python3 -m pip uninstall -y sccache; rm -f "$(which sccache)"
+ARG COMMON_WORKDIR
+WORKDIR ${COMMON_WORKDIR}
+
+
+# -----------------------
+# Install verl
+ARG VERL_REPO=https://github.com/volcengine/verl.git
+ARG VERL_BRANCH=main
+RUN pip install "tensordict==0.6.2" --no-deps && \
+    pip install accelerate \
+    codetiming \
+    datasets \
+    dill \
+    hydra-core \
+    liger-kernel \
+    numpy \
+    pandas \
+    peft \
+    "pyarrow>=15.0.0" \
+    pylatexenc \
+    torchdata \
+    wandb \
+    orjson \
+    pybind11
+
+WORKDIR /workspace/
+RUN git clone ${VERL_REPO} && \
+    cd verl && \
+    git checkout ${VERL_BRANCH} && \
+    pip install -e .
+
+# -----------------------------------------------------------------------------
+# Ray in Docker: avoid "MetricsHead failed to start" timeout
+# - Without dashboard (recommended if you don't need the UI):
+#     ray start --head --include-dashboard=false
+# - With dashboard: use the run flags below and:
+#     ray start --head --dashboard-host=0.0.0.0
+#
+# Example run (set shm-size and optionally network/ipc so dashboard can start):
+#   docker run --ipc=host --gpus all --network=host --shm-size=16g -it <image>
+# -----------------------------------------------------------------------------
+
+CMD ["/bin/bash"]

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -31,11 +31,6 @@ PPO_RAY_RUNTIME_ENV = {
         # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
         # https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
         "NCCL_CUMEM_ENABLE": "0",
-        # On ROCm, TaskRunner is created with num_gpus=0 but imports vLLM (which touches
-        # torch.cuda at import time). Prevent Ray from clearing HIP/CUDA visibility so
-        # that the TaskRunner process inherits the node's GPUs and the import succeeds.
-        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
-        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
     },
 }
 

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -31,6 +31,11 @@ PPO_RAY_RUNTIME_ENV = {
         # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
         # https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
         "NCCL_CUMEM_ENABLE": "0",
+        # On ROCm, TaskRunner is created with num_gpus=0 but imports vLLM (which touches
+        # torch.cuda at import time). Prevent Ray from clearing HIP/CUDA visibility so
+        # that the TaskRunner process inherits the node's GPUs and the import succeeds.
+        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
     },
 }
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -63,6 +63,10 @@ def run_ppo(config, task_runner_class=None) -> None:
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         default_runtime_env = get_ppo_ray_runtime_env()
         ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+        # If no address is set, use "local" so Ray starts a new local cluster instead of
+        # connecting to RAY_ADDRESS or /tmp/ray/ray_current_cluster (e.g. from a previous run).
+        if ray_init_kwargs.get("address") is None:
+            ray_init_kwargs = OmegaConf.create({**dict(ray_init_kwargs), "address": "local"})
         runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
 
         if config.transfer_queue.enable:


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test



- Built and ran the new Docker image on a ROCm 7.2 host (e.g. MI300 / MI250) and confirmed verl can start and use AMD GPUs.
- (Optional) Ran a minimal PPO/GRPO or rollout job with vLLM on ROCm and confirmed no device visibility errors.
- No new automated CI for ROCm (no AMD runners in upstream); manual validation on ROCm hardware is required.

### API and Usage Example

No API changes. Usage is the same; users select ROCm by environment and image:

```bash
# Build (optionally set PYTORCH_ROCM_ARCH for your GPU)
docker build -f docker/Dockerfile.rocm7.2 -t verl-rocm7.2 .

# Run with AMD GPUs visible to the container
docker run --ipc=host --device=/dev/kfd --device=/dev/dri --group-add=video \
  --cap-add=SYS_ADMIN -v .:/workspace -it verl-rocm7.2 bash

# Inside container: run verl as usual; HIP_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES
# are handled so Ray and vLLM see the same devices.
```

### Design & Code Changes

Keep existing CUDA/NPU behavior; add ROCm 7.2 as a supported backend via Docker, Ray env vars, and vLLM ROCm FP8 MoE integration.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
