### PR TITLE
rollout(vllm): ROCm fix for get_device_uuid + standalone rollout smoke & device-side coverage tests

### DIFF
--- a/tests/utils/test_device_rocm.py
+++ b/tests/utils/test_device_rocm.py
@@ -1,0 +1,98 @@
+# Copyright 2026 AMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Coverage for verl.utils.device on the ROCm (CUDA-compatible) path.
+
+verl maps AMD/HIP onto torch's "cuda" device namespace, so on a ROCm host these
+accessors exercise the is_cuda_available branches of the device abstraction --
+the primary ROCm support surface. NPU-only helpers are out of scope (excluded in
+.coveragerc.rocm). Falls back gracefully on a CPU-only host.
+"""
+
+import types
+
+import pytest
+import torch
+
+from verl.utils import device as dev
+
+
+def test_availability_flags():
+    assert isinstance(dev.is_cuda_available, bool)
+    assert isinstance(dev.is_npu_available, bool)
+    assert dev.is_torch_npu_available(check_device=False) in (True, False)
+
+
+def test_device_name_and_module():
+    name = dev.get_device_name()
+    assert name in ("cuda", "npu", "cpu")
+    mod = dev.get_torch_device()
+    assert mod is not None
+    if dev.is_cuda_available:
+        assert name == "cuda"
+        assert mod is torch.cuda
+
+
+def test_resource_and_visible_devices_keyword():
+    assert dev.get_resource_name() in ("GPU", "NPU")
+    kw = dev.get_visible_devices_keyword()
+    assert kw in ("CUDA_VISIBLE_DEVICES", "ASCEND_RT_VISIBLE_DEVICES")
+    if dev.is_cuda_available:
+        assert kw == "CUDA_VISIBLE_DEVICES"
+
+
+def test_nccl_backend():
+    backend = dev.get_nccl_backend()
+    assert backend in ("nccl", "hccl")
+    if dev.is_cuda_available:
+        assert backend == "nccl"
+
+
+def test_device_id_and_capability():
+    if not dev.is_cuda_available:
+        pytest.skip("no accelerator visible")
+    assert dev.get_device_id() >= 0
+    major, minor = dev.get_device_capability(0)
+    assert major is not None and minor is not None
+
+
+def test_capability_when_no_cuda():
+    # The (None, None) path is only taken without CUDA; just assert the contract.
+    major, minor = dev.get_device_capability(0)
+    if not dev.is_cuda_available:
+        assert (major, minor) == (None, None)
+
+
+def test_set_expandable_segments():
+    # No-op on CPU; on ROCm/CUDA it forwards to the allocator. Must not raise.
+    dev.set_expandable_segments(True)
+    dev.set_expandable_segments(False)
+
+
+def test_is_support_ipc():
+    # On a GPU (ROCm/CUDA) host this is unconditionally True.
+    result = dev.is_support_ipc()
+    assert isinstance(result, bool)
+    if dev.is_cuda_available:
+        assert result is True
+
+
+def test_auto_set_device_cuda_noop():
+    # On a non-NPU host auto_set_device must leave a "cuda" trainer device alone.
+    cfg = types.SimpleNamespace(trainer=types.SimpleNamespace(device="cuda"))
+    dev.auto_set_device(cfg)
+    if not dev.is_npu_available:
+        assert cfg.trainer.device == "cuda"
+    # None / missing-attr configs are tolerated.
+    dev.auto_set_device(None)
+    dev.auto_set_device(types.SimpleNamespace())

--- a/tests/utils/test_torch_functional_rocm.py
+++ b/tests/utils/test_torch_functional_rocm.py
@@ -1,0 +1,232 @@
+# Copyright 2026 AMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Device-side coverage for verl.utils.torch_functional (code-coverage tier).
+
+These exercise the pure tensor / scheduler helpers in torch_functional on the
+active accelerator device (HIP on ROCm), including the flash-attn cross-entropy
+path used by logprobs_from_logits. They are single-process and need only one
+GPU, so they are safe in the standalone ROCm coverage gate. They fall back to
+CPU when no accelerator is visible.
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+
+from verl.utils import torch_functional as tf
+
+
+def _device():
+    if torch.cuda.is_available():
+        return torch.device("cuda:0")
+    return torch.device("cpu")
+
+
+DEV = _device()
+
+
+def test_gather_from_labels():
+    data = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], device=DEV)
+    label = torch.tensor([2, 0], device=DEV)
+    out = tf.gather_from_labels(data, label)
+    torch.testing.assert_close(out, torch.tensor([0.3, 0.4], device=DEV))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_logprobs_from_logits_paths(dtype):
+    torch.manual_seed(0)
+    logits = torch.randn(4, 7, 11, device=DEV, dtype=dtype)
+    labels = torch.randint(0, 11, (4, 7), device=DEV)
+
+    # public entry (flash-attn path on GPU, v2 path on CPU)
+    lp = tf.logprobs_from_logits(logits, labels)
+    assert lp.shape == (4, 7)
+
+    # naive + v2 reference paths
+    naive = tf.logprobs_from_logits_naive(logits.float(), labels)
+    v2 = tf.logprobs_from_logits_v2(logits.float(), labels)
+    torch.testing.assert_close(naive, v2, atol=1e-4, rtol=1e-4)
+
+
+def test_clip_by_value():
+    x = torch.tensor([-2.0, 0.0, 5.0], device=DEV)
+    lo = torch.tensor([-1.0, -1.0, -1.0], device=DEV)
+    hi = torch.tensor([1.0, 1.0, 1.0], device=DEV)
+    out = tf.clip_by_value(x, lo, hi)
+    torch.testing.assert_close(out, torch.tensor([-1.0, 0.0, 1.0], device=DEV))
+
+
+def test_entropy_from_logits_and_chunking():
+    torch.manual_seed(1)
+    logits = torch.randn(5, 13, device=DEV)
+    ent = tf.entropy_from_logits(logits)
+    ent_chunked = tf.entropy_from_logits_with_chunking(logits, chunk_size=2)
+    assert ent.shape == (5,)
+    torch.testing.assert_close(ent, ent_chunked, atol=1e-4, rtol=1e-4)
+    # entropy is non-negative
+    assert torch.all(ent >= -1e-5)
+
+
+def test_masked_sum_mean_var_whiten():
+    values = torch.tensor([1.0, 2.0, 3.0, 4.0], device=DEV)
+    mask = torch.tensor([1.0, 1.0, 0.0, 1.0], device=DEV)
+    assert tf.masked_sum(values, mask).item() == pytest.approx(7.0)
+    assert tf.masked_mean(values, mask).item() == pytest.approx(7.0 / 3.0, abs=1e-4)
+
+    var = tf.masked_var(values, mask)
+    assert var.item() > 0
+    whit = tf.masked_whiten(values, mask)
+    assert whit.shape == values.shape
+    # shift_mean=False re-adds the mean
+    whit_nomean = tf.masked_whiten(values, mask, shift_mean=False)
+    assert whit_nomean.shape == values.shape
+
+
+def test_masked_var_error_paths():
+    values = torch.tensor([1.0, 2.0], device=DEV)
+    with pytest.raises(ValueError):
+        tf.masked_var(values, torch.tensor([0.0, 0.0], device=DEV))
+    with pytest.raises(ValueError):
+        tf.masked_var(values, torch.tensor([1.0, 0.0], device=DEV))
+
+
+@pytest.mark.parametrize("eos", [1, [1, 2]])
+def test_get_response_mask(eos):
+    response = torch.tensor(
+        [[20, 10, 34, 1, 0, 0, 0], [78, 0, 76, 2, 1, 0, 0]],
+        device=DEV,
+    )
+    mask = tf.get_response_mask(response, eos_token=eos)
+    assert mask.shape == response.shape
+    # every row keeps at least its first token
+    assert torch.all(mask[:, 0] == 1)
+
+
+def test_pad_helpers():
+    padded = tf.pad_2d_list_to_length([[1, 2], [3]], pad_token_id=0, max_length=4)
+    assert padded.tolist() == [[1, 2, 0, 0], [3, 0, 0, 0]]
+
+    t = torch.ones(2, 3, device=DEV)
+    right = tf.pad_sequence_to_length(t, max_seq_len=5, pad_token_id=0)
+    assert right.shape == (2, 5) and right[:, 3:].sum() == 0
+    left = tf.pad_sequence_to_length(t, max_seq_len=5, pad_token_id=0, left_pad=True)
+    assert left.shape == (2, 5) and left[:, :2].sum() == 0
+    # no-op when already long enough
+    assert tf.pad_sequence_to_length(t, max_seq_len=2, pad_token_id=0).shape == (2, 3)
+
+
+@pytest.mark.parametrize("truncation", ["left", "right", "middle"])
+def test_postprocess_data_truncation(truncation):
+    ids = torch.arange(2 * 8, device=DEV).reshape(2, 8)
+    mask = torch.ones(2, 8, device=DEV, dtype=torch.long)
+    out_ids, out_mask = tf.postprocess_data(ids, mask, max_length=4, pad_token_id=0, truncation=truncation)
+    assert out_ids.shape == (2, 4) and out_mask.shape == (2, 4)
+
+
+def test_postprocess_data_pad_and_error():
+    ids = torch.arange(2 * 3, device=DEV).reshape(2, 3)
+    mask = torch.ones(2, 3, device=DEV, dtype=torch.long)
+    out_ids, out_mask = tf.postprocess_data(ids, mask, max_length=6, pad_token_id=0, left_pad=True)
+    assert out_ids.shape == (2, 6)
+    with pytest.raises(NotImplementedError):
+        tf.postprocess_data(ids, mask, max_length=2, pad_token_id=0, truncation="error")
+
+
+def test_remove_pad_token():
+    ids = torch.tensor([[5, 6, 7], [8, 9, 0]], device=DEV)
+    mask = torch.tensor([[1, 1, 1], [1, 1, 0]], device=DEV)
+    out = tf.remove_pad_token(ids, mask)
+    assert out == [[5, 6, 7], [9, 0]]
+
+
+def test_log_probs_from_logits_response():
+    torch.manual_seed(2)
+    input_ids = torch.randint(0, 11, (2, 9), device=DEV)
+    logits = torch.randn(2, 9, 11, device=DEV)
+    out = tf.log_probs_from_logits_response(input_ids, logits, response_length=4)
+    assert out.shape == (2, 4)
+
+
+def test_post_process_logits():
+    logits = torch.randn(2, 5, device=DEV)
+    out = tf.post_process_logits(None, logits.clone(), temperature=2.0, top_k=0, top_p=1.0)
+    assert out.shape == logits.shape
+
+
+def test_calculate_sum_pi_squared():
+    logits = torch.randn(3, 8, device=DEV)
+    out = tf.calculate_sum_pi_squared_from_logits(logits)
+    expected = torch.softmax(logits, dim=-1).pow(2).sum(dim=-1)
+    torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_attention_mask_helpers():
+    bsz, tgt = 2, 5
+    causal = tf._make_causal_mask((bsz, tgt), torch.float32, DEV)
+    assert causal.shape == (bsz, 1, tgt, tgt)
+    attn = torch.ones(bsz, tgt, device=DEV)
+    expanded = tf._expand_mask(attn, torch.float32, tgt_len=tgt)
+    assert expanded.shape == (bsz, 1, tgt, tgt)
+    embeds = torch.zeros(bsz, tgt, 4, device=DEV)
+    combined = tf.prepare_decoder_attention_mask(attn, (bsz, tgt), embeds)
+    assert combined.shape == (bsz, 1, tgt, tgt)
+
+
+def test_get_unpad_data():
+    attn = torch.tensor([[1, 1, 0], [1, 1, 1]], device=DEV)
+    indices, cu_seqlens, max_seqlen = tf.get_unpad_data(attn)
+    assert max_seqlen == 3
+    assert cu_seqlens.tolist() == [0, 2, 5]
+    assert indices.numel() == 5
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda opt: tf.get_cosine_schedule_with_warmup(opt, num_warmup_steps=2, num_training_steps=10),
+        lambda opt: tf.get_cosine_schedule_with_warmup(
+            opt, num_warmup_steps=2, num_training_steps=10, min_lr_ratio=0.1, zero_indexed_step=False
+        ),
+        lambda opt: tf.get_constant_schedule_with_warmup(opt, num_warmup_steps=3),
+        lambda opt: tf.get_wsd_schedule_with_warmup(opt, num_warmup_steps=2, num_training_steps=10, stable_ratio=0.5),
+    ],
+)
+def test_lr_schedules(factory):
+    model = nn.Linear(2, 2)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1)
+    sched = factory(opt)
+    lrs = []
+    for _ in range(12):
+        opt.step()
+        sched.step()
+        lrs.append(opt.param_groups[0]["lr"])
+    assert all(math.isfinite(lr) and lr >= 0 for lr in lrs)
+
+
+def test_check_device_is_available():
+    if torch.cuda.is_available():
+        with tf.check_device_is_available():
+            pass
+    else:
+        pytest.skip("no accelerator visible")
+
+
+def test_compute_grad_norm():
+    model = nn.Linear(3, 1)
+    x = torch.randn(4, 3)
+    model(x).sum().backward()
+    gn = tf.compute_grad_norm(model)
+    assert gn >= 0

--- a/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
@@ -1,0 +1,125 @@
+# Copyright 2026 AMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ROCm vLLM rollout smoke test (code-coverage tier).
+
+Single-GPU, tiny-model (Qwen2.5-0.5B-Instruct), single short generation through
+verl's standalone vLLM rollout server. The point is COVERAGE of the real ROCm
+rollout path (vllm_async_server / vllm_rollout adapter / rollout utils), not a
+correctness/perf assertion -- so it only checks that generation produced tokens.
+
+Skips cleanly (rather than failing) when the prerequisites for a meaningful run
+are absent (no GPU, vllm missing, or the model cannot be fetched), so it is safe
+in the curated coverage set.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+MODEL_ID = os.environ.get("VERL_SMOKE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+
+
+def _require(cond, reason):
+    if not cond:
+        pytest.skip(reason)
+
+
+def test_vllm_rollout_smoke_rocm():
+    # ---- Preconditions (skip, don't fail, if the tier can't run this) --------
+    try:
+        import torch
+    except Exception:
+        pytest.skip("torch not importable")
+    _require(torch.cuda.is_available(), "no GPU visible")
+    _require(pytest.importorskip("vllm") is not None, "vllm not installed")
+
+    # ---- Fetch the tiny model (local snapshot) -------------------------------
+    try:
+        from huggingface_hub import snapshot_download
+
+        model_path = snapshot_download(MODEL_ID)
+    except Exception as exc:  # network/gated/etc.
+        pytest.skip(f"could not fetch {MODEL_ID}: {exc}")
+
+    import ray
+
+    ray.init(
+        runtime_env={"env_vars": {"VLLM_USE_V1": "1", "TOKENIZERS_PARALLELISM": "false"}},
+        ignore_reinit_error=True,
+    )
+    try:
+        from hydra import compose, initialize_config_dir
+
+        from verl.utils.tokenizer import normalize_token_ids
+
+        config_dir = os.path.abspath("verl/trainer/config")
+        if not os.path.exists(config_dir):
+            config_dir = os.path.abspath("verl/verl/trainer/config")
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            config = compose(config_name="ppo_trainer")
+
+        config.trainer.n_gpus_per_node = 1
+        config.trainer.nnodes = 1
+        config.actor_rollout_ref.model.path = model_path
+        config.actor_rollout_ref.rollout.name = "vllm"
+        config.actor_rollout_ref.rollout.mode = "async"
+        config.actor_rollout_ref.rollout.tensor_model_parallel_size = 1
+        config.actor_rollout_ref.rollout.prompt_length = 128
+        config.actor_rollout_ref.rollout.response_length = 32
+        # Keep it light: skip CUDA-graph capture, modest mem.
+        for k, v in (("enforce_eager", True), ("gpu_memory_utilization", 0.5), ("free_cache_engine", True)):
+            if k in config.actor_rollout_ref.rollout:
+                config.actor_rollout_ref.rollout[k] = v
+
+        from verl.workers.rollout.replica import get_rollout_replica_class
+
+        rollout_server_class = get_rollout_replica_class("vllm")
+        server = rollout_server_class(
+            replica_rank=0,
+            config=config.actor_rollout_ref.rollout,
+            model_config=config.actor_rollout_ref.model,
+            gpus_per_node=1,
+        )
+        asyncio.run(server.init_standalone())
+        server_handle = server._server_handle
+
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        prompt_ids = normalize_token_ids(
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": "Say hello in one short sentence."}],
+                add_generation_prompt=True,
+                tokenize=True,
+            )
+        )
+
+        output = ray.get(
+            server_handle.generate.remote(
+                request_id="smoke_0",
+                prompt_ids=prompt_ids,
+                sampling_params={"temperature": 0.0, "top_p": 1.0, "logprobs": False},
+                image_data=None,
+            ),
+            timeout=240.0,
+        )
+        assert output is not None and len(output.token_ids) > 0, "rollout produced no tokens"
+        print("SMOKE OK:", tokenizer.decode(output.token_ids)[:120])
+    finally:
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    test_vllm_rollout_smoke_rocm()

--- a/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
@@ -55,8 +55,26 @@ def test_vllm_rollout_smoke_rocm():
 
     import ray
 
+    # The vLLM rollout manages device visibility itself, so its ray workers (incl.
+    # the colocated CheckpointEngineWorker) require RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES
+    # to be set; otherwise ray rewrites *_VISIBLE_DEVICES under the worker and the
+    # rollout worker init hits an unimplemented device path. A coverage harness that
+    # also runs CPU-only single_controller tests may clear these flags globally, so
+    # re-assert them for THIS rollout via the cluster runtime_env.
+    rollout_env = {
+        "VLLM_USE_V1": "1",
+        "TOKENIZERS_PARALLELISM": "false",
+        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES": "1",
+        "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES": "1",
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
+    }
+    # Start from a clean cluster: when this test runs after other ray-using tests
+    # in the same session, a stale cluster would be reused and the runtime_env
+    # below silently ignored, breaking rollout worker init.
+    if ray.is_initialized():
+        ray.shutdown()
     ray.init(
-        runtime_env={"env_vars": {"VLLM_USE_V1": "1", "TOKENIZERS_PARALLELISM": "false"}},
+        runtime_env={"env_vars": rollout_env},
         ignore_reinit_error=True,
     )
     try:

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -62,7 +62,26 @@ def get_device_uuid(device_id: int) -> str:
         else:
             return f"NPU-{device_id}"
     else:
-        return current_platform.get_device_uuid(device_id)
+        try:
+            return current_platform.get_device_uuid(device_id)
+        except NotImplementedError:
+            # ROCm: vLLM's ROCm platform does not implement get_device_uuid
+            # (raises NotImplementedError). Derive a stable, unique per-device
+            # identifier from the visible-device env or torch device properties
+            # so the rollout server can initialize on AMD GPUs.
+            for env_var in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+                visible = os.getenv(env_var)
+                if visible:
+                    ids = visible.split(",")
+                    if device_id < len(ids):
+                        return f"ROCm-{ids[device_id].strip()}"
+            try:
+                uuid = getattr(torch.cuda.get_device_properties(device_id), "uuid", None)
+                if uuid is not None:
+                    return f"ROCm-{uuid}"
+            except Exception:
+                pass
+            return f"ROCm-{device_id}"
 
 
 def get_vllm_max_lora_rank(lora_rank: int):


### PR DESCRIPTION
## Summary

Enables verl's standalone vLLM rollout server to initialize on AMD/ROCm GPUs and
adds single-GPU (CPU-fallback safe) tests that exercise the real ROCm code paths.
These back a standalone ROCm code-coverage gate built on the prebuilt `rocm/vllm`
runtime (decoupled from the multi-hour release build).

- **Bug fix — `get_device_uuid` on ROCm.** vLLM's ROCm platform leaves
  `current_platform.get_device_uuid()` unimplemented (`NotImplementedError`),
  which prevented the standalone rollout server from initializing on AMD. Add a
  ROCm fallback that derives a stable per-device id from the visible-device env
  (`HIP/ROCR/CUDA_VISIBLE_DEVICES`) or torch device properties, else
  `ROCm-<device_id>`.
- **Rollout smoke test (`test_vllm_smoke_rocm.py`).** Tiny-model
  (Qwen2.5-0.5B-Instruct) single-generation through the standalone vLLM rollout
  server on one GPU; skips cleanly when GPU/vllm/model are unavailable. Hardened
  to run inside a shared pytest session: starts from a clean ray cluster (a stale
  cluster left by prior ray tests would swallow the `runtime_env`) and re-asserts
  `RAY_EXPERIMENTAL_NOSET_{HIP,ROCR,CUDA}_VISIBLE_DEVICES` so the rollout workers
  (incl. the colocated `CheckpointEngineWorker`) keep verl's manual device
  management.
- **Device-side coverage tests** (single-process, single-GPU, CPU-fallback safe):
  - `tests/utils/test_torch_functional_rocm.py` — pure tensor/scheduler helpers
    (gather, logprobs incl. the flash-attn cross-entropy path, clip, entropy,
    masked_*, padding/postprocess, attention-mask builders, unpad, LR schedules,
    grad-norm).
  - `tests/utils/test_device_rocm.py` — the `is_cuda_available` (ROCm-mapped)
    branches of the device abstraction.

## Test plan

- [x] `test_vllm_smoke_rocm.py` passes on MI325X (gfx942) via the prebuilt
      `rocm/vllm` runtime (single GPU).
- [x] `test_torch_functional_rocm.py` (26 cases) and `test_device_rocm.py`
      (9 cases) pass on ROCm.
- [x] Full curated ROCm coverage harvest is green (312 passed / 0 failed) and the
      changes are import-safe / skip cleanly on hosts without a GPU.

Made with [Cursor](https://cursor.com)