### PR TITLE
[ROCm] tests: single-GPU coverage for fsdp_utils + vllm rollout utils

### DIFF
--- a/tests/utils/test_fsdp_utils_rocm.py
+++ b/tests/utils/test_fsdp_utils_rocm.py
@@ -1,0 +1,263 @@
+# Copyright 2026 AMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ROCm code-coverage tests for verl.utils.fsdp_utils.
+
+Two groups:
+
+1. Pure-python helpers (no GPU / no torch.distributed): wrap-policy selection,
+   fsdp_version, optimizer offload/load, the meta-device init context manager,
+   and the shard-placement helper. These run on CPU and always execute.
+
+2. A SINGLE-GPU FSDP2 path (world_size=1, spawned via mp.spawn so distributed
+   state stays isolated from the rest of the curated suite). It wraps a tiny
+   Qwen2 model with fully_shard and exercises offload/load to CPU/GPU, the full
+   state-dict collection, fsdp2 grad-norm clipping, and reshard-after-forward.
+   Genuinely multi-rank FSDP1 sharding paths are out of scope here -- they
+   belong to the multi-GPU coverage tier.
+
+The point is COVERAGE of verl's own ROCm-relevant code, not numerical
+correctness, so assertions are intentionally light.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Group 1 -- pure-python helpers (CPU, no distributed)
+# ---------------------------------------------------------------------------
+
+
+class _MockDecoderLayer(nn.Module):
+    def __init__(self, hidden=32):
+        super().__init__()
+        self.lin = nn.Linear(hidden, hidden)
+
+
+class _MockCausalLM(nn.Module):
+    _no_split_modules = ["_MockDecoderLayer"]
+
+    def __init__(self, hidden=32, layers=2):
+        super().__init__()
+        self.config = SimpleNamespace(tie_word_embeddings=False)
+        self.embed = nn.Embedding(16, hidden)
+        self.layers = nn.ModuleList([_MockDecoderLayer(hidden) for _ in range(layers)])
+        self.lm_head = nn.Linear(hidden, 16, bias=False)
+
+
+def test_get_fsdp_wrap_policy_disable():
+    from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+    assert get_fsdp_wrap_policy(_MockCausalLM(), config={"disable": True}) is None
+
+
+def test_get_fsdp_wrap_policy_min_num_params():
+    from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+    policy = get_fsdp_wrap_policy(_MockCausalLM(), config={"min_num_params": 100})
+    assert policy is not None
+
+
+def test_get_fsdp_wrap_policy_transformer_cls():
+    from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+    # default_transformer_cls_names_to_wrap comes from _no_split_modules
+    policy = get_fsdp_wrap_policy(_MockCausalLM(), config={})
+    assert policy is not None
+
+
+def test_get_fsdp_wrap_policy_lora():
+    from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+    policy = get_fsdp_wrap_policy(_MockCausalLM(), config={}, is_lora=True)
+    assert policy is not None
+
+
+def test_get_fsdp_wrap_policy_none_config():
+    from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+    # config=None -> {} ; no min params and a model with _no_split_modules
+    assert get_fsdp_wrap_policy(_MockCausalLM(), config=None) is not None
+
+
+def test_fsdp_version_plain_module_is_zero():
+    from verl.utils.fsdp_utils import fsdp_version
+
+    assert fsdp_version(nn.Linear(4, 4)) == 0
+
+
+def test_get_shard_placement_fn():
+    from verl.utils.fsdp_utils import get_shard_placement_fn
+
+    fn = get_shard_placement_fn(fsdp_size=4)
+    # a param whose dim 0 is divisible by 4
+    placement = fn(torch.empty(8, 3))
+    assert placement is not None
+    # a param whose only divisible dim is not 0
+    placement2 = fn(torch.empty(3, 8))
+    assert placement2 is not None
+    # nothing divisible -> falls back to Shard(0)
+    placement3 = fn(torch.empty(3, 3))
+    assert placement3 is not None
+
+
+def test_offload_and_load_fsdp_optimizer_cpu():
+    from verl.utils.fsdp_utils import load_fsdp_optimizer, offload_fsdp_optimizer
+
+    model = nn.Linear(8, 8)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    # empty state -> early return path
+    offload_fsdp_optimizer(opt)
+    load_fsdp_optimizer(opt, device_id=torch.device("cpu"))
+    # build optimizer state via a step
+    loss = model(torch.randn(2, 8)).sum()
+    loss.backward()
+    opt.step()
+    offload_fsdp_optimizer(opt)
+    load_fsdp_optimizer(opt, device_id=torch.device("cpu"))
+
+
+def test_meta_device_init_creates_meta_params():
+    from verl.utils.fsdp_utils import meta_device_init
+
+    with meta_device_init():
+        m = nn.Linear(8, 8)
+    assert m.weight.is_meta
+
+
+def test_replace_lora_wrapper_passthrough():
+    """Non-target keys pass through unchanged; target keys get base_layer suffix."""
+    from verl.utils.fsdp_utils import replace_lora_wrapper
+
+    try:
+        from peft import LoraConfig
+
+        peft_config = LoraConfig(r=8, target_modules=["q_proj"], task_type="CAUSAL_LM")
+    except Exception as exc:  # pragma: no cover - peft must be present in the tier
+        pytest.skip(f"peft unavailable: {exc}")
+
+    # a non-weight/bias key returns unchanged
+    assert replace_lora_wrapper("model.norm", peft_config) == "model.norm"
+    # a stacked-param weight gets rewritten to base_layer
+    out = replace_lora_wrapper("model.layers.0.self_attn.q_proj.weight", peft_config)
+    assert out.endswith(".weight")
+
+
+# ---------------------------------------------------------------------------
+# Group 2 -- single-GPU FSDP2 path (world_size=1, isolated subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _fsdp2_single_gpu_worker(rank, rendezvous_file):
+    import torch.distributed as dist
+    from torch.distributed import init_device_mesh
+    from transformers import Qwen2Config
+    from transformers import AutoModelForCausalLM
+
+    from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device
+    from verl.utils.fsdp_utils import (
+        MixedPrecisionPolicy,
+        apply_fsdp2,
+        fsdp2_clip_grad_norm_,
+        fsdp_version,
+        get_fsdp_full_state_dict,
+        get_init_weight_context_manager,
+        load_fsdp2_model_to_gpu,
+        offload_fsdp2_model_to_cpu,
+        set_reshard_after_forward,
+    )
+
+    world_size = 1
+    get_torch_device().set_device(rank)
+    dist.init_process_group(
+        backend=get_nccl_backend(),
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        device_mesh = init_device_mesh(get_device_name(), mesh_shape=(world_size,), mesh_dim_names=("dp",))
+
+        # init-weight context manager (both branches)
+        _ = get_init_weight_context_manager(use_meta_tensor=True, mesh=device_mesh)
+        _ = get_init_weight_context_manager(use_meta_tensor=False)
+
+        cfg = Qwen2Config(
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            hidden_size=128,
+            intermediate_size=256,
+            vocab_size=512,
+        )
+        with torch.device(get_device_name()):
+            model = AutoModelForCausalLM.from_config(
+                config=cfg, torch_dtype=torch.bfloat16, attn_implementation="eager"
+            )
+            model = model.to(device=get_device_name())
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=torch.bfloat16, reduce_dtype=torch.float32, cast_forward_inputs=True
+        )
+        apply_fsdp2(model, {"mesh": device_mesh, "mp_policy": mp_policy}, {})
+        assert fsdp_version(model) == 2
+
+        # reshard-after-forward toggle (the runtime override helper)
+        try:
+            set_reshard_after_forward(model, True)
+        except Exception as exc:  # torch < 2.8 may lack the internal API
+            print(f"set_reshard_after_forward non-fatal: {type(exc).__name__}: {exc}")
+
+        # offload to CPU then load back to GPU
+        offload_fsdp2_model_to_cpu(model)
+        load_fsdp2_model_to_gpu(model)
+
+        # full (gathered) state dict -- fsdp2 path
+        sd = get_fsdp_full_state_dict(model, offload_to_cpu=True, rank0_only=True)
+        assert isinstance(sd, dict) and len(sd) > 0
+
+        # a tiny fwd/bwd to populate grads, then fsdp2 grad-norm clip
+        input_ids = torch.randint(0, 512, (1, 8), device=get_device_name())
+        out = model(input_ids=input_ids, labels=input_ids)
+        out.loss.backward()
+        total_norm = fsdp2_clip_grad_norm_(model.parameters(), max_norm=1.0)
+        assert total_norm is not None
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def test_fsdp2_single_gpu_paths():
+    if not torch.cuda.is_available():
+        pytest.skip("no GPU visible")
+    pytest.importorskip("transformers")
+    pytest.importorskip("accelerate")
+
+    import tempfile
+
+    import torch.multiprocessing as mp
+
+    with tempfile.TemporaryDirectory() as tmp:
+        rendezvous_file = os.path.join(tmp, "rdzv_fsdp2_single")
+        mp.spawn(fn=_fsdp2_single_gpu_worker, args=(rendezvous_file,), nprocs=1, join=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/workers/rollout/rollout_vllm/test_rollout_utils_rocm.py
+++ b/tests/workers/rollout/rollout_vllm/test_rollout_utils_rocm.py
@@ -1,0 +1,176 @@
+# Copyright 2026 AMD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ROCm code-coverage tests for verl.workers.rollout.vllm_rollout.utils.
+
+Targets the pure-python helpers that do NOT need a live vLLM worker / ZMQ
+transport: CLI-arg building, prompt-logprob extraction, LoRA rank rounding,
+the ROCm device-uuid fallback, the compute-logits monkeypatch, and the
+signal-suppression context manager. The heavy IPC weight-update path
+(update_weights_from_ipc) is exercised separately by the rollout smoke test.
+
+Importing this module needs vllm present (the rollout utils import from
+vllm.outputs), which the rocm/vllm coverage tier provides; the whole module
+skips cleanly otherwise.
+"""
+
+import signal
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from verl.workers.rollout.vllm_rollout.utils import (  # noqa: E402
+    build_cli_args_from_config,
+    extract_prompt_logprobs,
+    get_device_uuid,
+    get_vllm_max_lora_rank,
+    monkey_patch_compute_logits,
+    SuppressSignalInThread,
+)
+
+
+def test_build_cli_args_from_config_all_branches():
+    cfg = {
+        "skip_none": None,  # dropped
+        "flag_true": True,  # -> --flag-true
+        "flag_false": False,  # dropped
+        "empty_list": [],  # dropped
+        "sizes": [1, 2, 4],  # expanded
+        "json_dict": {"a": 1},  # json serialized
+        "scalar": "hello",  # --scalar hello
+        "number": 7,
+    }
+    args = build_cli_args_from_config(cfg)
+    assert "--skip_none" not in args
+    assert "--flag_true" in args
+    assert "--flag_false" not in args
+    assert "--empty_list" not in args
+    # list expansion
+    i = args.index("--sizes")
+    assert args[i + 1 : i + 4] == ["1", "2", "4"]
+    # dict -> json
+    j = args.index("--json_dict")
+    assert args[j + 1] == '{"a": 1}'
+    # scalar / number
+    assert args[args.index("--scalar") + 1] == "hello"
+    assert args[args.index("--number") + 1] == "7"
+
+
+def test_get_vllm_max_lora_rank_rounds_up():
+    # rounds up to the nearest allowed rank
+    assert get_vllm_max_lora_rank(4) >= 4
+    assert get_vllm_max_lora_rank(8) >= 8
+
+
+def test_get_vllm_max_lora_rank_invalid():
+    with pytest.raises(AssertionError):
+        get_vllm_max_lora_rank(0)
+    with pytest.raises(ValueError):
+        get_vllm_max_lora_rank(100000)
+
+
+def _lp(logprob, rank):
+    return SimpleNamespace(logprob=logprob, rank=rank)
+
+
+def test_extract_prompt_logprobs_none_is_noop():
+    result = {}
+    extract_prompt_logprobs(SimpleNamespace(prompt_logprobs=None), None, result)
+    assert result == {}
+
+
+def test_extract_prompt_logprobs_zero():
+    # num_prompt_logprobs == 0 -> single top token per position
+    out = SimpleNamespace(prompt_logprobs=[None, {"5": _lp(-0.1, 1)}, {"7": _lp(-0.2, 1)}])
+    result = {}
+    extract_prompt_logprobs(out, 0, result)
+    assert "prompt_ids" in result and "prompt_logprobs" in result
+    assert result["prompt_ids"][0] == [5]
+
+
+def test_extract_prompt_logprobs_topk():
+    out = SimpleNamespace(
+        prompt_logprobs=[
+            None,
+            {"5": _lp(-0.1, 1), "9": _lp(-0.5, 2)},
+            {"7": _lp(-0.2, 1), "3": _lp(-0.9, 2)},
+        ]
+    )
+    result = {}
+    extract_prompt_logprobs(out, 2, result)
+    assert result["prompt_ids"][0] == [5, 9]
+
+
+def test_get_device_uuid_returns_string():
+    # On ROCm the vLLM platform raises NotImplementedError and the fallback
+    # derives a stable id from the visible-device env. Assert it produces a
+    # non-empty identifier rather than a specific value (varies by build).
+    import os
+
+    prev = os.environ.get("HIP_VISIBLE_DEVICES")
+    os.environ["HIP_VISIBLE_DEVICES"] = "0,1"
+    try:
+        uuid = get_device_uuid(0)
+    finally:
+        if prev is None:
+            os.environ.pop("HIP_VISIBLE_DEVICES", None)
+        else:
+            os.environ["HIP_VISIBLE_DEVICES"] = prev
+    assert isinstance(uuid, str) and len(uuid) > 0
+
+
+def test_monkey_patch_compute_logits_masks_oov():
+    import torch
+
+    class _FakeModel:
+        def compute_logits(self, *args, **kwargs):
+            return torch.zeros(1, 8)
+
+    model = _FakeModel()
+    monkey_patch_compute_logits(model, vocab_size=4)
+    logits = model.compute_logits()
+    # tokens >= vocab_size masked to -inf
+    assert torch.isinf(logits[..., 4:]).all()
+    assert not torch.isinf(logits[..., :4]).any()
+
+
+def test_suppress_signal_in_thread():
+    with SuppressSignalInThread():
+        # registering a signal handler from a non-main thread is a no-op
+        done = {}
+
+        def worker():
+            try:
+                signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+                done["ok"] = True
+            except Exception as exc:  # pragma: no cover
+                done["err"] = exc
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+        assert done.get("ok") is True
+    # signal.signal is restored after the context: registering from the main
+    # thread works normally again.
+    prev = signal.getsignal(signal.SIGUSR1)
+    signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+    signal.signal(signal.SIGUSR1, prev)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py
@@ -135,6 +135,52 @@ def test_vllm_rollout_smoke_rocm():
         )
         assert output is not None and len(output.token_ids) > 0, "rollout produced no tokens"
         print("SMOKE OK:", tokenizer.decode(output.token_ids)[:120])
+
+        # ---- Extra coverage of the async server lifecycle ---------------------
+        # These exercise more of vllm_async_server (sampling variants, KV-cache
+        # reset, abort/resume, sleep/wake offload, profiler hooks) on the real
+        # ROCm stack. They are best-effort: the smoke gate is the generation
+        # above, so any op that a given vllm/ROCm build does not support is
+        # logged and skipped rather than failing the curated coverage set.
+        def _aux(label, fn):
+            try:
+                fn()
+                print(f"SMOKE {label}: ok")
+            except Exception as exc:  # noqa: BLE001 - coverage, not correctness
+                print(f"SMOKE {label}: non-fatal {type(exc).__name__}: {exc}")
+
+        # (1) A second generation with a different sampling profile (stochastic,
+        #     top-k/top-p, logprobs on) to cover the non-greedy params path.
+        def _gen2():
+            out = ray.get(
+                server_handle.generate.remote(
+                    request_id="smoke_1",
+                    prompt_ids=prompt_ids,
+                    sampling_params={
+                        "temperature": 0.7,
+                        "top_p": 0.95,
+                        "top_k": 50,
+                        "logprobs": True,
+                        "max_tokens": 16,
+                    },
+                    image_data=None,
+                ),
+                timeout=240.0,
+            )
+            assert out is not None
+
+        _aux("gen2", _gen2)
+        # (2) KV-cache reset.
+        _aux("clear_kv_cache", lambda: asyncio.run(server.clear_kv_cache()))
+        # (3) Partial-rollout abort then resume.
+        _aux("abort_all_requests", lambda: asyncio.run(server.abort_all_requests()))
+        _aux("resume_generation", lambda: asyncio.run(server.resume_generation()))
+        # (4) Sleep (offload weights/KV to host) then wake.
+        _aux("sleep", lambda: asyncio.run(server.sleep()))
+        _aux("wake_up", lambda: asyncio.run(server.wake_up()))
+        # (5) Profiler start/stop hooks.
+        _aux("start_profile", lambda: asyncio.run(server.start_profile()))
+        _aux("stop_profile", lambda: asyncio.run(server.stop_profile()))
     finally:
         ray.shutdown()
 


### PR DESCRIPTION
## Summary
Adds curated **single-GPU** tests that raise ROCm-subsystem code coverage in the `generic/code-coverage` lane, with no multi-rank / multi-node requirement.

This is the companion to **AMD-AIOSS/aisw-ci-builder-tester#681**, which references these files in the coverage entrypoint's default test set. Together they move ROCm-subsystem coverage from **49.9% → ~60%** (measured locally on `rocm/vllm:latest`, single MI300X, 352 passed / 0 failed).

## Changes
- **`tests/utils/test_fsdp_utils_rocm.py`** (new): pure helpers + single-GPU FSDP2 paths in `verl/utils/fsdp_utils.py` (~14% → ~39%).
- **`tests/workers/rollout/rollout_vllm/test_rollout_utils_rocm.py`** (new): pure helper functions in `verl/workers/rollout/vllm_rollout/utils.py` (~19% → ~54%), no real vLLM worker.
- **`tests/workers/rollout/rollout_vllm/test_vllm_smoke_rocm.py`** (mod): extend the smoke test with best-effort async-server lifecycle ops (sampling variants, KV-cache reset, abort/resume, sleep/wake offload, profiler hooks). Non-fatal by design — the generation assertion stays the gate, so ops unsupported by a given vllm/ROCm build are logged and skipped.

## Test plan
- [x] Local single-GPU harvest on `rocm/vllm:latest`: 352 passed / 0 failed
- [ ] CI green once paired with aisw-ci-builder-tester#681

Made with [Cursor](https://cursor.com)